### PR TITLE
name_resolve should be an ArgCommand, not a Command

### DIFF
--- a/ipfsApi/client.py
+++ b/ipfsApi/client.py
@@ -59,7 +59,7 @@ class Client(object):
         # ADVANCED COMMANDS
         self.resolve            =  ArgCommand('/resolve')
         self.name_publish       =  ArgCommand('/name/publish')
-        self.name_resolve       =     Command('/name/resolve')
+        self.name_resolve       =  ArgCommand('/name/resolve')
         self.dns                =  ArgCommand('/dns')
         self.pin_add            =  ArgCommand('/pin/add')
         self.pin_rm             =  ArgCommand('/pin/rm')


### PR DESCRIPTION
Assuming that I am trying to use name_resolve correctly:

    >>> api.name_resolve('QmXfrS3pHerg44zzK6QKQj6JDk8H6cMtQS7pdXbohwNQfK')

It looks as if it needs to be specified as an `ArgCommand`, rather than
as a `Command`.