### PR TITLE
use defaults when host, port, or base == None

### DIFF
--- a/ipfsApi/client.py
+++ b/ipfsApi/client.py
@@ -8,6 +8,9 @@ from .commands import Command, \
                       FileCommand
 from .exceptions import InvalidCommand
 
+default_host = 'localhost'
+default_port = 5001
+default_base = 'api/v0'
 
 
 class Client(object):
@@ -16,11 +19,18 @@ class Client(object):
 
 
     def __init__(self,
-                 host='127.0.0.1',
-                 port=5001,
-                 base='api/v0',
+                 host=None,
+                 port=None,
+                 base=None,
                  default_enc='json',
                  **defaults):
+
+        if host is None:
+            host = default_host
+        if port is None:
+            port = default_port
+        if base is None:
+            base = default_base
         
         self._client = self.__client__(host, port, base, default_enc)
         


### PR DESCRIPTION
This permits the caller to request the default value explicitly
by pasing None to either host, port, or base when instantiating
ipfsApi.client.Client.

Closes #7