### PR TITLE
Add Python 3.x support

### DIFF
--- a/ipfsApi/__init__.py
+++ b/ipfsApi/__init__.py
@@ -1,1 +1,3 @@
-from client import *
+from __future__ import absolute_import
+
+from .client import *

--- a/ipfsApi/client.py
+++ b/ipfsApi/client.py
@@ -37,7 +37,7 @@ class Client(object):
         self._client = self.__client__(host, port, base, default_enc)
         
         # default request keyword-args
-        if defaults.has_key('opts'):
+        if 'opts' in defaults:
             defaults['opts'].update({'encoding': default_enc})
         else:
             defaults.update({'opts': {'encoding': default_enc}})

--- a/ipfsApi/client.py
+++ b/ipfsApi/client.py
@@ -1,6 +1,8 @@
 """
 IPFS API Bindings for Python
 """
+from __future__ import absolute_import
+
 from . import http
 from . import utils
 from .commands import Command, \

--- a/ipfsApi/commands.py
+++ b/ipfsApi/commands.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 import os
 import fnmatch
 import functools

--- a/ipfsApi/commands.py
+++ b/ipfsApi/commands.py
@@ -10,6 +10,7 @@ from . import filestream
 from .exceptions import InvalidArguments, \
                         FileCommandException
 
+import six
 
 
 class Command(object):
@@ -49,7 +50,7 @@ class FileCommand(Command):
             return self.recursive(client, f, **kwargs)
         if isinstance(f, (list, tuple)):
             return self.multiple(client, f, **kwargs)
-        if isinstance(f, basestring) and os.path.isdir(f):
+        if isinstance(f, six.string_types) and os.path.isdir(f):
             ls = [os.path.join(f,p) for p in os.listdir(f)]
             fs = [p for p in ls if os.path.isfile(p)]
             return self.multiple(client, fs, **kwargs)

--- a/ipfsApi/commands.py
+++ b/ipfsApi/commands.py
@@ -51,7 +51,7 @@ class FileCommand(Command):
             return self.multiple(client, f, **kwargs)
         if isinstance(f, basestring) and os.path.isdir(f):
             ls = [os.path.join(f,p) for p in os.listdir(f)]
-            fs = filter(os.path.isfile, ls)
+            fs = [p for p in ls if os.path.isfile(p)]
             return self.multiple(client, fs, **kwargs)
         else:
             return self.single(client, f, **kwargs)

--- a/ipfsApi/encoding.py
+++ b/ipfsApi/encoding.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 import json
 
 from .exceptions import EncodingException

--- a/ipfsApi/filestream.py
+++ b/ipfsApi/filestream.py
@@ -9,9 +9,10 @@ from __future__ import absolute_import
 
 import os
 import fnmatch
-from urllib import quote
 from uuid import uuid4
-from cStringIO import StringIO
+
+from six.moves.urllib.parse import quote
+from six.moves import cStringIO as StringIO
 
 from . import utils
 

--- a/ipfsApi/filestream.py
+++ b/ipfsApi/filestream.py
@@ -5,6 +5,8 @@ Streaming Multipart Encoded Files
 **NOTE: This is temporary until we can fork python-requests and/or urllib3 to
         provide the same functionality.
 """
+from __future__ import absolute_import
+
 import os
 import fnmatch
 from urllib import quote

--- a/ipfsApi/http.py
+++ b/ipfsApi/http.py
@@ -2,6 +2,8 @@
 HTTP client for api requests.  This is pluggable into the IPFS Api client and
 can/will eventually be supplemented with an asynchronous version.
 """
+from __future__ import absolute_import
+
 import requests
 import contextlib
 

--- a/ipfsApi/http.py
+++ b/ipfsApi/http.py
@@ -36,7 +36,7 @@ class HTTPClient(object):
         for arg in args:
             params.append(('arg', arg))
 
-        method = 'post' if (files or kwargs.has_key('data')) else 'get'
+        method = 'post' if (files or 'data' in kwargs) else 'get'
         
         if self._session:
             res = self._session.request(method, url,

--- a/ipfsApi/utils.py
+++ b/ipfsApi/utils.py
@@ -33,8 +33,8 @@ def guess_mimetype(filename):
 
 def ls_dir(dirname):
     ls = os.listdir(dirname)
-    files = filter(lambda p: os.path.isfile(os.path.join(dirname, p)), ls)
-    dirs  = filter(lambda p: os.path.isdir(os.path.join(dirname, p)), ls)
+    files = [p for p in ls if os.path.isfile(os.path.join(dirname, p))]
+    dirs  = [p for p in ls if os.path.isdir(os.path.join(dirname, p))]
     return files, dirs
         
 

--- a/ipfsApi/utils.py
+++ b/ipfsApi/utils.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 import os
 import json
 import mimetypes

--- a/ipfsApi/utils.py
+++ b/ipfsApi/utils.py
@@ -3,8 +3,10 @@ from __future__ import absolute_import
 import os
 import json
 import mimetypes
-import cPickle as pickle
-from cStringIO import StringIO
+
+import six
+from six.moves import cPickle as pickle
+from six.moves import cStringIO as StringIO
 
 
 def make_string_buffer(string):

--- a/ipfsApi/utils.py
+++ b/ipfsApi/utils.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 
+import io
 import os
 import json
 import mimetypes
@@ -10,7 +11,10 @@ from six.moves import cStringIO as StringIO
 
 
 def make_string_buffer(string):
-    buf = StringIO()
+    if isinstance(string, six.text_type):
+        buf = StringIO()
+    else:
+        buf = io.BytesIO()
     buf.write(string)
     buf.seek(0)
     return buf
@@ -25,7 +29,9 @@ def make_pyobj_buffer(py_obj):
     return make_string_buffer(pickle.dumps(py_obj))
 
 def parse_pyobj(pickled):
-    return pickle.loads(str(pickled))
+    if isinstance(pickled, six.text_type):
+        pickled = pickled.encode('ascii')
+    return pickle.loads(pickled)
 
 
 def guess_mimetype(filename):

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,6 @@
+[bdist_wheel]
+# This flag says that the code is written to work on both Python 2 and Python
+# 3. If at all possible, it is good practice to do this. If you cannot, you
+# will need to generate wheels for each Python version that you support.
+universal=1
+

--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,9 @@ setup(
     # your project is installed. For an analysis of "install_requires" vs pip's
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
-    install_requires=['requests>=2.2.1']
+    install_requires=[
+        'requests>=2.2.1',
+        'six',
+    ],
 
 )

--- a/setup.py
+++ b/setup.py
@@ -41,10 +41,10 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
-        #'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3',
         #'Programming Language :: Python :: 3.2',
-        #'Programming Language :: Python :: 3.3',
-        #'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: 3.4',
     ],
 
     # What does your project relate to?


### PR DESCRIPTION
 - Uses six (and add it to install_requires) to cover moved/renamed modules

Fixes ipfs/python-ipfs-api#9

I also have doctests for ipfsApi.utils, those will be a separate PR