### PR TITLE
raise ipfsApiError on http errors

### DIFF
--- a/ipfsApi/exceptions.py
+++ b/ipfsApi/exceptions.py
@@ -1,14 +1,17 @@
-class InvalidCommand(Exception):
+class ipfsApiError(Exception):
     pass
 
-class InvalidArguments(Exception):
+class InvalidCommand(ipfsApiError):
     pass
 
-class InvalidPath(Exception):
+class InvalidArguments(ipfsApiError):
     pass
 
-class FileCommandException(Exception):
+class InvalidPath(ipfsApiError):
     pass
 
-class EncodingException(Exception):
+class FileCommandException(ipfsApiError):
+    pass
+
+class EncodingException(ipfsApiError):
     pass

--- a/ipfsApi/http.py
+++ b/ipfsApi/http.py
@@ -34,8 +34,8 @@ class HTTPClient(object):
         for arg in args:
             params.append(('arg', arg))
 
-        method = 'post' if (files or kwargs.has_key('data')) else 'get'
-        
+        method = 'post' if (files or 'data' in kwargs) else 'get'
+
         if self._session:
             res = self._session.request(method, url,
                                         params=params, files=files, **kwargs)


### PR DESCRIPTION
This causes `ipfsApi.http.HTTPClient` to raise an exception in response to
HTTP errors, rather than successfully returning an error message to the
caller.  This makes it easier to differentiate errors from successful
responses.

Closes #13.