### PR TITLE
Add doctests for utils, and tox support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist/
 *.pyc
 *.swp
 *~
+.tox/

--- a/ipfsApi/utils.py
+++ b/ipfsApi/utils.py
@@ -11,6 +11,19 @@ from six.moves import cStringIO as StringIO
 
 
 def make_string_buffer(string):
+    """Returns a readable/writeable file-like object, containing string.
+
+    >>> f = make_string_buffer(u'text')
+    >>> print(f.read())
+    text
+
+    If the string is a bytestring, then the returned object will
+    operate in binary mode.
+
+    >>> f = make_string_buffer(b'bytes')
+    >>> f.read() == b'bytes'
+    True
+    """
     if isinstance(string, six.text_type):
         buf = StringIO()
     else:
@@ -20,15 +33,40 @@ def make_string_buffer(string):
     return buf
 
 def make_json_buffer(json_obj):
+    """Returns a file-like object containing json_obj serialized to JSON
+
+    >>> f = make_json_buffer([1, 2, 3, True, {u'distance': 4.5}])
+    >>> f.read()
+    '[1, 2, 3, true, {"distance": 4.5}]'
+    """
     return make_string_buffer(json.dumps(json_obj))
 
 def parse_json(json_str):
+    """Returns a Python object unserialized from JSON in json_str
+
+    >>> parse_json('[1, 2, 3, true, 4.5, null, 6e3]')
+    [1, 2, 3, True, 4.5, None, 6000.0]
+    """
     return json.loads(json_str)
 
 def make_pyobj_buffer(py_obj):
+    """Returns a file-like object containing py_obj serialized to a pickle
+
+    >>> f = make_pyobj_buffer([1, 2, 3, True, 4.5, None, 6e3])
+    >>> isinstance(f.read(), bytes)
+    True
+    """
     return make_string_buffer(pickle.dumps(py_obj))
 
 def parse_pyobj(pickled):
+    r"""Returns a Python object unpickled from the provided string
+
+    >>> parse_pyobj(b'(lp0\nI1\naI2\naI3\naI01\naF4.5\naNaF6000.0\na.')
+    [1, 2, 3, True, 4.5, None, 6000.0]
+
+    >>> parse_pyobj(u'(lp0\nI1\naI2\naI3\naI01\naF4.5\naNaF6000.0\na.')
+    [1, 2, 3, True, 4.5, None, 6000.0]
+    """
     if isinstance(pickled, six.text_type):
         pickled = pickled.encode('ascii')
     return pickle.loads(pickled)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
+pytest
 requests==2.2.1
 six

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,3 +4,13 @@
 # will need to generate wheels for each Python version that you support.
 universal=1
 
+[pytest]
+python_files =
+    test_*.py
+    *_test.py
+    tests.py
+addopts =
+    --doctest-modules
+    ipfsApi
+    test
+

--- a/test/tests.py
+++ b/test/tests.py
@@ -1,10 +1,10 @@
+import os
 import unittest
-
-import sys
-sys.path.append('..')
 
 import ipfsApi
 
+
+HERE = os.path.dirname(os.path.abspath(__file__))
 
 class IpfsApiTest(unittest.TestCase):
 
@@ -67,6 +67,13 @@ class IpfsApiTest(unittest.TestCase):
                       u'Name': u'fake_dir/test2'},
                      {u'Hash': u'QmYqqgRahxbZvudnzDu2ZzUS1vFSNEuCrxghM8hgT8uBFY',
                       u'Name': u'fake_dir'}]
+
+    def setUp(self):
+        self._olddir = os.getcwd()
+        os.chdir(HERE)
+
+    def tearDown(self):
+        os.chdir(self._olddir)
 
     #########
     # TESTS #

--- a/test/tests.py
+++ b/test/tests.py
@@ -27,8 +27,7 @@ class IpfsApiTest(unittest.TestCase):
             {'Hash': u'QmbZuss6aAizLEAt2Jt2BD29oq4XfMieGezi6mN4vz9g9A',
              'Name': 'fake_dir'}]
 
-    fake_lookup = {i['Name']: i['Hash'] for i in fake}
-  
+    fake_lookup = dict((i['Name'], i['Hash']) for i in fake)
 
     ## test_add_multiple_from_list
     fake_file  = 'fake_dir/fsdfgh'

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,12 @@
+[tox]
+envlist =
+    py26,
+    py27,
+    py33,
+    py34,
+
+[testenv]
+deps =
+    -rrequirements.txt
+commands =
+    py.test


### PR DESCRIPTION
This pull request
 - Adds docstrings with docstrings to ipfsApi.utils
 - Adds py.test as the test runner
 - Adds Tox configuration
 - Fixes the IpfsApiTest under Python 2.6

To run the test suite
```
ipfs daemon &
pip install tox
tox
```