### PR TITLE
avoid having both __client__ and _client in the same class

### DIFF
--- a/ipfsApi/client.py
+++ b/ipfsApi/client.py
@@ -17,8 +17,7 @@ default_base = 'api/v0'
 
 class Client(object):
 
-    __client__ = http.HTTPClient
-
+    _clientfactory = http.HTTPClient
 
     def __init__(self,
                  host=None,
@@ -34,7 +33,7 @@ class Client(object):
         if base is None:
             base = default_base
         
-        self._client = self.__client__(host, port, base, default_enc)
+        self._client = self._clientfactory(host, port, base, default_enc)
         
         # default request keyword-args
         if 'opts' in defaults:


### PR DESCRIPTION
This addresses the discussion in #11 by replacing `__client__` with
`_clientfactory`, since that's what it does.