### PR TITLE
Add pep8 tests to tox configuration

### DIFF
--- a/ipfsApi/client.py
+++ b/ipfsApi/client.py
@@ -5,9 +5,7 @@ from __future__ import absolute_import
 
 from . import http
 from . import utils
-from .commands import Command, \
-                      ArgCommand, \
-                      FileCommand
+from .commands import Command, ArgCommand, FileCommand
 from .exceptions import InvalidCommand
 
 default_host = 'localhost'
@@ -32,9 +30,9 @@ class Client(object):
             port = default_port
         if base is None:
             base = default_base
-        
+
         self._client = self._clientfactory(host, port, base, default_enc)
-        
+
         # default request keyword-args
         if 'opts' in defaults:
             defaults['opts'].update({'encoding': default_enc})
@@ -43,17 +41,16 @@ class Client(object):
 
         self._defaults = defaults
 
-
         ############
         # COMMANDS #
         ############
-        
+
         # BASIC COMMANDS
         self.add                = FileCommand('/add')
         self.cat                =  ArgCommand('/cat')
         self.ls                 =  ArgCommand('/ls')
         self.refs               =  ArgCommand('/refs')
-        
+
         # DATA STRUCTURE COMMANDS
         self.block_stat         =  ArgCommand('/block/stat')
         self.block_get          =  ArgCommand('/block/get')
@@ -96,13 +93,12 @@ class Client(object):
                                               post_hook=lambda r: r[u"Extra"])
         self.dht_put            =  ArgCommand('/dht/put', argc=2)
         self.ping               =  ArgCommand('/ping')
-        
+
         # TOOL COMMANDS
         self.config             =  ArgCommand('/config')
         self.config_show        =     Command('/config/show')
         self.config_replace     =  ArgCommand('/config/replace')
         self.version            =     Command('/version')
-
 
     def __getattribute__(self, name):
         """
@@ -121,7 +117,6 @@ class Client(object):
             else:
                 raise AttributeError
 
-
     ###########
     # HELPERS #
     ###########
@@ -133,7 +128,7 @@ class Client(object):
             return res['Hash']
         except:
             return res
-    
+
     def add_json(self, json_obj, **kwargs):
         """Adds a json-serializable Python dict as a json file to IPFS."""
         res = self.add(utils.make_json_buffer(json_obj), **kwargs)
@@ -145,7 +140,7 @@ class Client(object):
     def get_json(self, multihash, **kwargs):
         """Loads a json object from IPFS."""
         return self.cat(multihash, decoder='json', **kwargs)
-        
+
     def add_pyobj(self, py_obj, **kwargs):
         """Adds a picklable Python object as a file to IPFS."""
         res = self.add(utils.make_pyobj_buffer(py_obj), **kwargs)

--- a/ipfsApi/encoding.py
+++ b/ipfsApi/encoding.py
@@ -5,9 +5,8 @@ import json
 from .exceptions import EncodingException
 
 
-
 class Encoding(object):
-    
+
     def parse(self, string):
         raise NotImplemented
 
@@ -36,7 +35,7 @@ class Json(Encoding):
         cur = idx
         while cur < len(json_string) - 1:
             obj, idx = self.decoder.raw_decode(json_string[cur:])
-            results.append(obj) 
+            results.append(obj)
             cur += idx
 
         if len(results) == 1:
@@ -54,14 +53,13 @@ class Protobuf(Encoding):
 class Xml(Encoding):
     name = 'xml'
 
-
-
 # encodings supported by the IPFS api (default is json)
 __encodings = {
-            Json.name:     Json,
-        Protobuf.name: Protobuf,
-             Xml.name:      Xml
-        }
+    Json.name: Json,
+    Protobuf.name: Protobuf,
+    Xml.name: Xml
+}
+
 
 def get_encoding(name):
     try:

--- a/ipfsApi/exceptions.py
+++ b/ipfsApi/exceptions.py
@@ -1,17 +1,22 @@
 class ipfsApiError(Exception):
     pass
 
+
 class InvalidCommand(ipfsApiError):
     pass
+
 
 class InvalidArguments(ipfsApiError):
     pass
 
+
 class InvalidPath(ipfsApiError):
     pass
 
+
 class FileCommandException(ipfsApiError):
     pass
+
 
 class EncodingException(ipfsApiError):
     pass

--- a/ipfsApi/http.py
+++ b/ipfsApi/http.py
@@ -25,9 +25,9 @@ class HTTPClient(object):
                 args=[], opts={}, files=[],
                 decoder=None, post_hook=None,
                 **kwargs):
-        
+
         url = self.base + path
-        
+
         params = []
         params.append(('stream-channels', 'true'))
         for opt in opts.items():

--- a/ipfsApi/utils.py
+++ b/ipfsApi/utils.py
@@ -32,6 +32,7 @@ def make_string_buffer(string):
     buf.seek(0)
     return buf
 
+
 def make_json_buffer(json_obj):
     """Returns a file-like object containing json_obj serialized to JSON
 
@@ -41,6 +42,7 @@ def make_json_buffer(json_obj):
     """
     return make_string_buffer(json.dumps(json_obj))
 
+
 def parse_json(json_str):
     """Returns a Python object unserialized from JSON in json_str
 
@@ -48,6 +50,7 @@ def parse_json(json_str):
     [1, 2, 3, True, 4.5, None, 6000.0]
     """
     return json.loads(json_str)
+
 
 def make_pyobj_buffer(py_obj):
     """Returns a file-like object containing py_obj serialized to a pickle
@@ -57,6 +60,7 @@ def make_pyobj_buffer(py_obj):
     True
     """
     return make_string_buffer(pickle.dumps(py_obj))
+
 
 def parse_pyobj(pickled):
     r"""Returns a Python object unpickled from the provided string
@@ -80,7 +84,5 @@ def guess_mimetype(filename):
 def ls_dir(dirname):
     ls = os.listdir(dirname)
     files = [p for p in ls if os.path.isfile(os.path.join(dirname, p))]
-    dirs  = [p for p in ls if os.path.isdir(os.path.join(dirname, p))]
+    dirs = [p for p in ls if os.path.isdir(os.path.join(dirname, p))]
     return files, dirs
-        
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
-pytest
 requests>=2.2.1
 six

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
         'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        #'Programming Language :: Python :: 3.2',
+        # 'Programming Language :: Python :: 3.2',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
     ],
@@ -52,7 +52,7 @@ setup(
 
     # You can just specify the packages manually here if your project is
     # simple. Or you can use find_packages().
-    packages=['ipfsApi'],
+    packages=find_packages(),
 
     # List run-time dependencies here.  These will be installed by pip when
     # your project is installed. For an analysis of "install_requires" vs pip's

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,0 +1,2 @@
+flake8
+pytest

--- a/tools/pre-commit
+++ b/tools/pre-commit
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+if [ "x$1" = "x--install" ]; then
+	top_dir=$(git rev-parse --show-toplevel)
+	git_dir=$(git rev-parse --git-dir)
+
+	if [ -f "$git_dir/hooks/pre-commit" ]; then
+		echo "ERROR: found existing pre-commit hook; " \
+			"cowardly giving up." >&2
+		exit 1
+	fi
+
+	echo "installing pre-commit hook in $git_dir/hooks"
+
+	ln -s $top_dir/tools/pre-commit $git_dir/hooks/pre-commit
+	exit
+fi
+
+# run pep8 tests before accepting a commit
+tox -e pep8

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,22 @@
 [tox]
+minversion = 1.6
 envlist =
+    pep8,
     py26,
     py27,
     py33,
     py34,
 
 [testenv]
-deps =
-    -rrequirements.txt
+deps = -r{toxinidir}/requirements.txt
+       -r{toxinidir}/test-requirements.txt
 commands =
-    py.test
+    py.test {posargs}
+
+[testenv:pep8]
+commands =
+  flake8 {posargs}
+
+[flake8]
+ignore = E222,E221,F403
+exclude =  .venv,.git,.tox,dist,doc,*egg,build,tools,test


### PR DESCRIPTION
417bf08 (Lars Kellogg-Stedman, 3 minutes ago)
   fix all pep8 errors

   this commits corrects all the pep8 errors reported by flake8 with the
   following exceptions:

   - we ignore everything in test/, because there are a number of
    problems there right now.

   - we explicitly disable checks E222 and E221 (too much whitespace
    before/after operators), because we're doing fancy alignment of
    multiple assignments in several of the source files

   - we explicitly disable check F403 (`from something import *`), because
    we use that construct on purpiose.

abd8880 (Lars Kellogg-Stedman, 5 minutes ago)
   add support for pep8 tests in tox config

   this commit configures tox to run [pep8][] tests.  It also moves
   test-related requirements (like `pytest`) into the file
   `test-requirements.txt`, which means they won't be installed when someone
   simply runs `pip install ipfs-api`, etc.

   You can run *just* the pep8 tests like this:

       tox -e pep8

   [pep8]: https://www.python.org/dev/peps/pep-0008/