### PR TITLE
Add support for specifying HTTPS or HTTP in the hostname.

### DIFF
--- a/ipfsApi/http.py
+++ b/ipfsApi/http.py
@@ -4,6 +4,7 @@ can/will eventually be supplemented with an asynchronous version.
 """
 from __future__ import absolute_import
 
+import re
 import requests
 import contextlib
 
@@ -28,7 +29,10 @@ class HTTPClient(object):
     def __init__(self, host, port, base, default_enc, **defaults):
         self.host = host
         self.port = port
-        self.base = 'http://%s:%s/%s' % (host, port, base)
+        if not re.match('^https?://', host.lower()):
+            host = 'http://' + host
+
+        self.base = '%s:%s/%s' % (host, port, base)
 
         # default request keyword-args
         if 'opts' in defaults:


### PR DESCRIPTION
It's best to use SSL when pulling from a gateway, but the way this was written originally didn't allow for that. This is a backwards-compatible way to add support for that use case.