### PR TITLE
support streaming for /cat option with stream=True

### DIFF
--- a/ipfsApi/http.py
+++ b/ipfsApi/http.py
@@ -71,6 +71,10 @@ class HTTPClient(object):
                                    params=params, files=files, **kwargs)
 
         if not decoder:
+            # return raw stream
+            if kwargs.get('stream'):
+                return res.raw
+
             if path == '/cat':
                 # since <api>/cat only returns the raw data and not an encoded
                 # object, dont't try to parse it automatically.


### PR DESCRIPTION
Check for `stream=True` option for requests and just return the raw stream.

Useful for `cat`, especially when retrieving non-text data
eg:

```
r = api.cat('<hash>', stream=True)
data = r.read()
```